### PR TITLE
Disable PR preview GitHub Actions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,13 +1,13 @@
 ---
 name: Deploy PR previews
 
-on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+# on:
+#   pull_request:
+#     types:
+#       - opened
+#       - reopened
+#       - synchronize
+#       - closed
 
 concurrency: preview-${{ github.ref }}
 


### PR DESCRIPTION
[Deploy PR Preview action](https://github.com/marketplace/actions/deploy-pr-preview)は、現行バージョンでは別のリポジトリからのPRでうまく動かないため、一旦削除