### PR TITLE
Fix typo in error section

### DIFF
--- a/docs/03-advanced/03-error/index.mdx
+++ b/docs/03-advanced/03-error/index.mdx
@@ -13,7 +13,7 @@ import Answer from "@site/src/components/Answer";
 
 コンピューターでは、浮動小数点方式が使われます。浮動小数点方式では、仮数部と指数部によって数値を表現します。
 
-$12345 = \underbrace{1.2345}_{\text{仮数部}}\times 10^{\overbrace{-4}^{\text{指数部}}}$
+$12345 = \underbrace{1.2345}_{\text{仮数部}}\times 10^{\overbrace{4}^{\text{指数部}}}$
 
 物理的制約があるので、仮数部と指数部は有限桁でしか扱えません。
 


### PR DESCRIPTION
誤差の章に誤植があるとの指摘をいただいたため、修正しました。
$12345=1.2345 \times 10^{-4}$ と表記されていたのを、 $12345=1.2345×10^4$ に修正しました。